### PR TITLE
init.qcom.usb.rc: change mtp_tx_req_len value to fix MTP read

### DIFF
--- a/rootdir/init.qcom.usb.rc
+++ b/rootdir/init.qcom.usb.rc
@@ -65,7 +65,7 @@ on boot
 
     write /sys/class/android_usb/f_mass_storage/lun/nofua 1
     write /sys/class/android_usb/android0/f_rndis_qc/rndis_transports BAM2BAM_IPA
-    write /sys/module/g_android/parameters/mtp_tx_req_len 131072 
+    write /sys/module/g_android/parameters/mtp_tx_req_len 16384 
     write /sys/module/g_android/parameters/mtp_rx_req_len 131072
 
 # Following are the parameters required for usb functionality. They provide configurable options like


### PR DESCRIPTION
The value of **mtp_tx_req_len** is exceed and will cause a issue that you can't read a large file via MTP, miui stock kernel's value is 4096*4, corresponding to kernel source.